### PR TITLE
feat: restore original filenames (strip copy-suffixes on cluster move)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ file_cluster.py -i inbox -w zdjecia -d dataframe
 ```
 Other run options:
 ```
-usage: file_cluster.py [-h] [-i INBOX_DIR] [-o OUTPUT_DIR] [-w WATCH_DIR] [-t] [-n] [-y] [-f] [-d] [-c] [--version]
+usage: file_cluster.py [-h] [-i INBOX_DIR] [-o OUTPUT_DIR] [-w WATCH_DIR] [-t] [-n] [-y] [-f] [-d] [-c] [-r] [--version]
 
 Group media files by event
 
@@ -56,6 +56,9 @@ optional arguments:
                         Force recalculate cluster info for each existing cluster.
   -d, --drop-duplicates
   -c, --use-existing-clusters
+  -r, --restore-original-names
+                        Revert copy-suffixed file names (e.g. '-Kopiuj(1)', ' - Copy') to
+                        their originals when moving files, unless a name collision occurs
   --version             show program's version number and exit
 
 ```

--- a/src/filecluster/configuration.py
+++ b/src/filecluster/configuration.py
@@ -108,6 +108,7 @@ class FileClusterSettings(BaseSettings):
     force_deep_scan: bool = False
     assign_to_clusters_existing_in_libs: bool = False
     skip_duplicated_existing_in_libs: bool = False
+    restore_original_names: bool = False
 
     # Time settings
     time_granularity_minutes: int = 60
@@ -175,6 +176,8 @@ class Config:
         force_deep_scan: Whether to perform deep scanning of files
         assign_to_clusters_existing_in_libs: Whether to use existing clusters
         skip_duplicated_existing_in_libs: Whether to skip duplicated files
+        restore_original_names: Whether to revert copy-suffixed file names to
+            their originals when moving/copying into cluster folders
     """
 
     in_dir_name: Path
@@ -189,6 +192,7 @@ class Config:
     force_deep_scan: bool
     assign_to_clusters_existing_in_libs: bool
     skip_duplicated_existing_in_libs: bool
+    restore_original_names: bool = False
 
     def __repr__(self) -> str:
         rep = [f"{p}:\t{self.__getattribute__(p)}" for p in self.__dataclass_fields__]
@@ -293,6 +297,7 @@ class ConfigFactory:
             force_deep_scan=self.settings.force_deep_scan,
             assign_to_clusters_existing_in_libs=self.settings.assign_to_clusters_existing_in_libs,
             skip_duplicated_existing_in_libs=self.settings.skip_duplicated_existing_in_libs,
+            restore_original_names=self.settings.restore_original_names,
         )
 
     @staticmethod
@@ -306,6 +311,7 @@ class ConfigFactory:
         copy_mode: bool | None = None,
         drop_duplicates: bool | None = None,
         use_existing_clusters: bool | None = None,
+        restore_original_names: bool | None = None,
         **kwargs: Any,
     ) -> Config:
         """Override config parameters with CLI arguments.
@@ -320,6 +326,7 @@ class ConfigFactory:
             copy_mode: Whether to use copy mode
             drop_duplicates: Whether to skip duplicated files
             use_existing_clusters: Whether to use existing clusters
+            restore_original_names: Whether to revert copy-suffixed file names
             **kwargs: Additional overrides
 
         Returns:
@@ -341,6 +348,8 @@ class ConfigFactory:
             config.skip_duplicated_existing_in_libs = drop_duplicates
         if use_existing_clusters is not None:
             config.assign_to_clusters_existing_in_libs = use_existing_clusters
+        if restore_original_names is not None:
+            config.restore_original_names = restore_original_names
 
         # Handle operation mode overrides
         if copy_mode:
@@ -397,6 +406,7 @@ def override_config_with_cli_params(
     force_deep_scan: bool | None = None,
     drop_duplicates: bool | None = None,
     use_existing_clusters: bool | None = None,
+    restore_original_names: bool | None = None,
 ) -> Config:
     """Override config with CLI parameters (backwards compatibility)."""
     return default_factory.override_from_cli(
@@ -409,4 +419,5 @@ def override_config_with_cli_params(
         copy_mode=copy_mode,
         drop_duplicates=drop_duplicates,
         use_existing_clusters=use_existing_clusters,
+        restore_original_names=restore_original_names,
     )

--- a/src/filecluster/file_cluster.py
+++ b/src/filecluster/file_cluster.py
@@ -29,6 +29,7 @@ def main(
     force_deep_scan: bool | None = None,
     drop_duplicates: bool | None = None,
     use_existing_clusters: bool | None = None,
+    restore_original_names: bool | None = None,
 ) -> dict[str, Any]:
     """Run clustering on the media files provided as inbox.
 
@@ -45,6 +46,8 @@ def main(
         force_deep_scan: Force recalculation of cluster info for existing clusters
         drop_duplicates: Skip clustering duplicates and store them in a separate folder
         use_existing_clusters: Try to assign media to existing clusters in watch folders
+        restore_original_names: Revert copy-suffixed file names (e.g. "-Kopiuj(1)")
+            to their originals when moving/copying into cluster folders
 
     Returns:
         Dictionary with diagnostic data from the clustering process
@@ -64,6 +67,7 @@ def main(
         copy_mode=copy_mode,
         drop_duplicates=drop_duplicates,
         use_existing_clusters=use_existing_clusters,
+        restore_original_names=restore_original_names,
     )
 
     # Read cluster info from libraries (or get empty DataFrame if none found)
@@ -275,6 +279,16 @@ def create_argument_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=False,
     )
+    parser.add_argument(
+        "-r",
+        "--restore-original-names",
+        help=(
+            "Revert copy-suffixed file names (e.g. '-Kopiuj(1)', ' - Copy') to "
+            "their originals when moving files, unless a name collision occurs"
+        ),
+        action="store_true",
+        default=False,
+    )
 
     return parser
 
@@ -322,6 +336,7 @@ def run_from_cli():
         force_deep_scan=args.force_deep_scan,
         drop_duplicates=args.drop_duplicates,
         use_existing_clusters=args.use_existing_clusters,
+        restore_original_names=args.restore_original_names,
     )
 
 

--- a/src/filecluster/file_operations.py
+++ b/src/filecluster/file_operations.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import math
 import os
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from shutil import copy2, move
@@ -18,6 +19,108 @@ from tqdm import tqdm
 from filecluster import logger
 from filecluster.configuration import CopyMode
 from filecluster.exceptions import DateStringNoneError
+
+# Copy-suffix patterns appended (by file managers) just before the extension.
+# Stripped, in order, from the end of the file *stem*:
+#   - Polish Windows: "-Kopiuj", "-Kopiuj(1)"
+#   - English Windows: " - Copy", " - Copy (2)"
+#   - Bare numeric duplicate marker: " (1)", "(1)"
+_COPY_SUFFIX_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"-Kopiuj(?:\s*\(\d+\))?$"),
+    re.compile(r"\s*-\s*Copy(?:\s*\(\d+\))?$", re.IGNORECASE),
+    re.compile(r"\s*\(\d+\)$"),
+)
+
+
+def strip_copy_suffix(name: str) -> str:
+    """Return *name* with a trailing copy-suffix removed from its stem.
+
+    The file extension is preserved.  If no known copy-suffix is present, the
+    original name is returned unchanged.
+
+    Examples:
+        ``IMG_0017-Kopiuj(2).HEIC`` -> ``IMG_0017.HEIC``
+        ``photo - Copy (3).jpg``    -> ``photo.jpg``
+        ``photo (1).jpg``           -> ``photo.jpg``
+        ``IMG_0017.HEIC``           -> ``IMG_0017.HEIC`` (unchanged)
+    """
+    p = Path(name)
+    suffix = p.suffix  # includes leading dot, '' if none
+    stem = p.name[: len(p.name) - len(suffix)] if suffix else p.name
+
+    for pattern in _COPY_SUFFIX_PATTERNS:
+        new_stem, n_subs = pattern.subn("", stem)
+        if n_subs:
+            return f"{new_stem}{suffix}"
+    return name
+
+
+def resolve_destination_names(
+    inbox_media_df,
+    out_dir: Path,
+    restore: bool,
+) -> dict[str, str]:
+    """Map each inbox ``file_name`` to its destination basename.
+
+    When *restore* is False, the mapping is the identity (destination equals
+    source name).  When True, copy-suffixes are stripped where it is safe to do
+    so: a de-suffixed name is only used if it does not collide with a file
+    already present in the target directory or with another file in the same run
+    landing in the same directory.  Files that already have no suffix claim their
+    name first, so true originals win and copies fall back to their suffixed
+    names on collision.
+
+    Args:
+        inbox_media_df: DataFrame with ``file_name`` and ``target_path`` columns.
+        out_dir: Output directory root (used to inspect existing target dirs).
+        restore: Whether to attempt reverting to original (de-suffixed) names.
+
+    Returns:
+        Mapping of original ``file_name`` -> destination basename.
+    """
+    if not restore:
+        return {
+            row["file_name"]: row["file_name"] for _, row in inbox_media_df.iterrows()
+        }
+
+    # Per-target-dir set of already-claimed (lower-cased) names, seeded with
+    # whatever already exists on disk in that directory.
+    claimed: dict[str, set[str]] = {}
+
+    def _claimed_for(target_path: str) -> set[str]:
+        if target_path not in claimed:
+            existing: set[str] = set()
+            dir_path = Path(out_dir) / str(target_path)
+            if dir_path.is_dir():
+                existing = {p.name.lower() for p in dir_path.iterdir() if p.is_file()}
+            claimed[target_path] = existing
+        return claimed[target_path]
+
+    mapping: dict[str, str] = {}
+
+    # Process un-suffixed originals first so they always keep their name, then
+    # the remaining (suffixed) files in deterministic order.
+    rows = list(inbox_media_df.iterrows())
+    originals = [
+        r for _, r in rows if strip_copy_suffix(r["file_name"]) == r["file_name"]
+    ]
+    suffixed = [
+        r for _, r in rows if strip_copy_suffix(r["file_name"]) != r["file_name"]
+    ]
+    suffixed.sort(key=lambda r: str(r["file_name"]))
+
+    for row in [*originals, *suffixed]:
+        name = row["file_name"]
+        target_path = row["target_path"]
+        claimed_names = _claimed_for(str(target_path))
+
+        desired = strip_copy_suffix(name)
+        chosen = desired if desired.lower() not in claimed_names else name
+
+        claimed_names.add(chosen.lower())
+        mapping[name] = chosen
+
+    return mapping
 
 
 @dataclass(frozen=True)
@@ -91,6 +194,7 @@ def build_file_operation_plan(
     in_dir: Path,
     out_dir: Path,
     mode: CopyMode,
+    restore_original_names: bool = False,
 ) -> FileOperationPlan:
     """Build a plan of file operations from the fully-annotated media DataFrame.
 
@@ -99,6 +203,10 @@ def build_file_operation_plan(
         in_dir: Inbox directory (source).
         out_dir: Output directory (destination root).
         mode: COPY, MOVE, or NOP.
+        restore_original_names: When True, strip copy-suffixes from destination
+            file names (e.g. ``IMG_0017-Kopiuj(2).HEIC`` -> ``IMG_0017.HEIC``),
+            unless doing so would collide with an existing or already-claimed
+            name in the target folder.
 
     Returns:
         A FileOperationPlan ready to be executed (or inspected).
@@ -125,10 +233,16 @@ def build_file_operation_plan(
             raise DateStringNoneError()
         plan.ops.append(MkdirOp(path=Path(out_dir) / str(dir_name)))
 
+    # Resolve destination basenames (optionally reverting copy-suffixes)
+    dst_names = resolve_destination_names(
+        inbox_media_df, Path(out_dir), restore=restore_original_names
+    )
+
     # Plan file operations
     for _, row in inbox_media_df.iterrows():
         src = Path(in_dir) / row["file_name"]
-        dst = Path(out_dir) / str(row["target_path"]) / row["file_name"]
+        dst_name = dst_names[row["file_name"]]
+        dst = Path(out_dir) / str(row["target_path"]) / dst_name
         if mode == CopyMode.COPY:
             plan.ops.append(CopyOp(src=src, dst=dst))
         elif mode == CopyMode.MOVE:

--- a/src/filecluster/image_grouper.py
+++ b/src/filecluster/image_grouper.py
@@ -262,6 +262,7 @@ class ImageGrouper:
             in_dir=Path(self.config.in_dir_name),
             out_dir=Path(self.config.out_dir_name),
             mode=self.config.mode,
+            restore_original_names=self.config.restore_original_names,
         )
 
     def move_files_to_cluster_folder(self):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -90,6 +90,7 @@ class TestFileClusterSettings:
         assert s.force_deep_scan is False
         assert s.assign_to_clusters_existing_in_libs is False
         assert s.skip_duplicated_existing_in_libs is False
+        assert s.restore_original_names is False
 
     def test_cluster_df_columns_schema(self):
         """Verify the expected column schema for cluster DataFrames."""
@@ -293,6 +294,17 @@ class TestCliOverride:
         config = get_default_config()
         updated = default_factory.override_from_cli(config, force_deep_scan=True)
         assert updated.force_deep_scan is True
+
+    def test_restore_original_names_defaults_false(self):
+        """The restore-original-names flag is off by default."""
+        config = get_default_config()
+        assert config.restore_original_names is False
+
+    def test_override_restore_original_names(self):
+        """CLI --restore-original-names flag propagates to config."""
+        config = get_default_config()
+        updated = default_factory.override_from_cli(config, restore_original_names=True)
+        assert updated.restore_original_names is True
 
     def test_nop_mode_overrides_copy_mode(self):
         """

--- a/tests/test_file_cluster.py
+++ b/tests/test_file_cluster.py
@@ -11,7 +11,7 @@ import tempfile
 
 import pytest
 
-from filecluster.file_cluster import main, process_watch_dirs
+from filecluster.file_cluster import create_argument_parser, main, process_watch_dirs
 
 
 # ---------------------------------------------------------------------------
@@ -43,6 +43,25 @@ class TestProcessWatchDirs:
     def test_empty_list_returns_empty(self):
         """Explicit empty list is valid."""
         assert process_watch_dirs([]) == []
+
+
+class TestArgumentParser:
+    """Tests for the CLI argument parser."""
+
+    def test_restore_original_names_flag_defaults_false(self):
+        """The --restore-original-names flag defaults to False."""
+        parser = create_argument_parser()
+        args = parser.parse_args([])
+        assert args.restore_original_names is False
+
+    def test_restore_original_names_flag_can_be_set(self):
+        """Both the short and long forms enable the flag."""
+        parser = create_argument_parser()
+        assert parser.parse_args(["-r"]).restore_original_names is True
+        assert (
+            parser.parse_args(["--restore-original-names"]).restore_original_names
+            is True
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_restore_filenames.py
+++ b/tests/test_restore_filenames.py
@@ -1,0 +1,198 @@
+"""Tests for the restore-original-filenames feature.
+
+Covers:
+- strip_copy_suffix (pure string helper)
+- resolve_destination_names (collision-aware mapping)
+- build_file_operation_plan(restore_original_names=True) behaviour
+"""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from filecluster.configuration import CopyMode
+from filecluster.file_operations import (
+    CopyOp,
+    MoveOp,
+    build_file_operation_plan,
+    resolve_destination_names,
+    strip_copy_suffix,
+)
+
+
+class TestStripCopySuffix:
+    """Unit tests for the pure strip_copy_suffix helper."""
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("IMG_0017-Kopiuj(2).HEIC", "IMG_0017.HEIC"),
+            ("IMG_0017-Kopiuj(1).HEIC", "IMG_0017.HEIC"),
+            ("IMG_0017-Kopiuj.HEIC", "IMG_0017.HEIC"),
+            ("photo - Copy.jpg", "photo.jpg"),
+            ("photo - Copy (3).jpg", "photo.jpg"),
+            ("photo (1).jpg", "photo.jpg"),
+            ("photo(1).jpg", "photo.jpg"),
+            # No copy-suffix -> unchanged
+            ("IMG_0017.HEIC", "IMG_0017.HEIC"),
+            ("vacation.jpg", "vacation.jpg"),
+        ],
+    )
+    def test_strip(self, name, expected):
+        assert strip_copy_suffix(name) == expected
+
+    def test_extension_preserved_case(self):
+        """The original extension casing is preserved."""
+        assert strip_copy_suffix("IMG_0017-Kopiuj(2).HEIC").endswith(".HEIC")
+
+    def test_no_extension(self):
+        """Files without an extension are handled."""
+        assert strip_copy_suffix("README-Kopiuj(1)") == "README"
+
+
+class TestResolveDestinationNames:
+    """Tests for the collision-aware destination-name resolver."""
+
+    @pytest.fixture()
+    def inbox_df(self):
+        # The user's real-world example, single target cluster.
+        names = [
+            "IMG_0015-Kopiuj(1).HEIC",
+            "IMG_0015.HEIC",
+            "IMG_0016-Kopiuj(1).HEIC",
+            "IMG_0016-Kopiuj(2).HEIC",
+            "IMG_0016.HEIC",
+            "IMG_0017-Kopiuj(1).HEIC",
+            "IMG_0017-Kopiuj(2).HEIC",
+            "IMG_0017.HEIC",
+        ]
+        return pd.DataFrame(
+            {"file_name": names, "target_path": ["new/cluster1"] * len(names)}
+        )
+
+    def test_restore_disabled_is_identity(self, inbox_df, tmp_path):
+        mapping = resolve_destination_names(inbox_df, tmp_path, restore=False)
+        for name in inbox_df["file_name"]:
+            assert mapping[name] == name
+
+    def test_true_originals_keep_their_name(self, inbox_df, tmp_path):
+        mapping = resolve_destination_names(inbox_df, tmp_path, restore=True)
+        assert mapping["IMG_0015.HEIC"] == "IMG_0015.HEIC"
+        assert mapping["IMG_0016.HEIC"] == "IMG_0016.HEIC"
+        assert mapping["IMG_0017.HEIC"] == "IMG_0017.HEIC"
+
+    def test_copies_keep_suffix_when_original_present(self, inbox_df, tmp_path):
+        """Since the un-suffixed original exists, copies must NOT be renamed."""
+        mapping = resolve_destination_names(inbox_df, tmp_path, restore=True)
+        assert mapping["IMG_0017-Kopiuj(1).HEIC"] == "IMG_0017-Kopiuj(1).HEIC"
+        assert mapping["IMG_0017-Kopiuj(2).HEIC"] == "IMG_0017-Kopiuj(2).HEIC"
+
+    def test_no_destination_collisions(self, inbox_df, tmp_path):
+        """All resolved destination names within a cluster are unique."""
+        mapping = resolve_destination_names(inbox_df, tmp_path, restore=True)
+        dests = list(mapping.values())
+        assert len(dests) == len(set(dests))
+
+    def test_single_copy_no_original_is_promoted(self, tmp_path):
+        """A lone copy with no un-suffixed original gets de-suffixed."""
+        df = pd.DataFrame(
+            {
+                "file_name": ["IMG_0099-Kopiuj(1).HEIC"],
+                "target_path": ["new/cluster1"],
+            }
+        )
+        mapping = resolve_destination_names(df, tmp_path, restore=True)
+        assert mapping["IMG_0099-Kopiuj(1).HEIC"] == "IMG_0099.HEIC"
+
+    def test_two_copies_first_wins(self, tmp_path):
+        """With two copies and no original, only one claims the stripped name."""
+        df = pd.DataFrame(
+            {
+                "file_name": [
+                    "IMG_0099-Kopiuj(1).HEIC",
+                    "IMG_0099-Kopiuj(2).HEIC",
+                ],
+                "target_path": ["new/cluster1", "new/cluster1"],
+            }
+        )
+        mapping = resolve_destination_names(df, tmp_path, restore=True)
+        dests = sorted(mapping.values())
+        assert "IMG_0099.HEIC" in dests
+        # the other one keeps its suffixed name
+        assert "IMG_0099-Kopiuj(2).HEIC" in dests
+
+    def test_collision_with_existing_file_on_disk(self, tmp_path):
+        """If the de-suffixed name already exists on disk, keep the suffix."""
+        cluster_dir = tmp_path / "new" / "cluster1"
+        cluster_dir.mkdir(parents=True)
+        (cluster_dir / "IMG_0099.HEIC").write_text("existing")
+
+        df = pd.DataFrame(
+            {
+                "file_name": ["IMG_0099-Kopiuj(1).HEIC"],
+                "target_path": ["new/cluster1"],
+            }
+        )
+        mapping = resolve_destination_names(df, tmp_path, restore=True)
+        assert mapping["IMG_0099-Kopiuj(1).HEIC"] == "IMG_0099-Kopiuj(1).HEIC"
+
+
+class TestBuildPlanWithRestore:
+    """build_file_operation_plan honours restore_original_names."""
+
+    @pytest.fixture()
+    def inbox_df(self):
+        return pd.DataFrame(
+            {
+                "file_name": ["IMG_1.HEIC", "IMG_2-Kopiuj(1).HEIC"],
+                "target_path": ["new/c1", "new/c1"],
+            }
+        )
+
+    def test_default_keeps_original_destination_names(self, inbox_df):
+        """Without the flag, dst basename equals the inbox file name."""
+        plan = build_file_operation_plan(
+            inbox_media_df=inbox_df,
+            in_dir=Path("/inbox"),
+            out_dir=Path("/out"),
+            mode=CopyMode.MOVE,
+        )
+        dsts = {op.dst.name for op in plan.ops if isinstance(op, MoveOp)}
+        assert dsts == {"IMG_1.HEIC", "IMG_2-Kopiuj(1).HEIC"}
+
+    def test_restore_strips_suffix_in_destination(self, inbox_df):
+        """With the flag, the copy is renamed but src stays the inbox name."""
+        plan = build_file_operation_plan(
+            inbox_media_df=inbox_df,
+            in_dir=Path("/inbox"),
+            out_dir=Path("/out"),
+            mode=CopyMode.MOVE,
+            restore_original_names=True,
+        )
+        moves = {op.src.name: op.dst.name for op in plan.ops if isinstance(op, MoveOp)}
+        assert moves["IMG_1.HEIC"] == "IMG_1.HEIC"
+        # source unchanged, destination de-suffixed
+        assert moves["IMG_2-Kopiuj(1).HEIC"] == "IMG_2.HEIC"
+
+    def test_restore_works_in_copy_mode(self, inbox_df):
+        plan = build_file_operation_plan(
+            inbox_media_df=inbox_df,
+            in_dir=Path("/inbox"),
+            out_dir=Path("/out"),
+            mode=CopyMode.COPY,
+            restore_original_names=True,
+        )
+        copies = {op.src.name: op.dst.name for op in plan.ops if isinstance(op, CopyOp)}
+        assert copies["IMG_2-Kopiuj(1).HEIC"] == "IMG_2.HEIC"
+
+    def test_nop_mode_unaffected(self, inbox_df):
+        plan = build_file_operation_plan(
+            inbox_media_df=inbox_df,
+            in_dir=Path("/inbox"),
+            out_dir=Path("/out"),
+            mode=CopyMode.NOP,
+            restore_original_names=True,
+        )
+        assert plan.n_skips == 2
+        assert plan.n_moves == 0


### PR DESCRIPTION
## Summary

Adds an **opt-in** option to revert Windows-style copy-suffixed filenames to their originals when moving/copying files into cluster folders.

Example: `IMG_0017-Kopiuj(2).HEIC` → `IMG_0017.HEIC`

## Behavior
- New flag: `-r/--restore-original-names` (config `FILECLUSTER_RESTORE_ORIGINAL_NAMES`); default **OFF**.
- Strips: `-Kopiuj(N)`, ` - Copy`, ` - Copy (N)`, trailing `(N)`.
- **Collision-safe:** if the de-suffixed name already exists in the target folder or is claimed by another file in the same run, the file keeps its suffixed name; the rest are still renamed.
- True originals (no suffix) claim their name first, so copies fall back when needed.
- Only affects COPY/MOVE; NOP/dry-run unchanged. Source (inbox) names never change — only destination.

## Changes
- `file_operations.py`: pure `strip_copy_suffix()` + collision-aware `resolve_destination_names()`; new `restore_original_names` param on `build_file_operation_plan`.
- `image_grouper.py`: threads config flag through.
- `configuration.py`: new setting + `Config` field + override wiring.
- `file_cluster.py`: CLI flag + `main()` param.
- README updated.

## Testing (TDD)
- 26 new tests written first (red), then implemented to green.
- Full suite: **221 passed** (was 195). `ruff check`, `ruff format --check`, and `ty check` all clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>